### PR TITLE
(#3) ScreenUtil 패키지 적용하기

### DIFF
--- a/yoochanhong_and_children/lib/main.dart
+++ b/yoochanhong_and_children/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:yoochanhong_and_children/screen/my_home_page.dart';
+import 'package:yoochanhong_and_children/screen/protector_registration_page.dart';
 
 void main() => runApp(const MyApp());
 
@@ -8,9 +10,12 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      debugShowCheckedModeBanner: false,
-      home: MyHomePage(),
+    return ScreenUtilInit(
+      designSize: const Size(430, 932),
+      builder: (context, child) => const MaterialApp(
+        home: ProtectorRegistrationPage(),
+        debugShowCheckedModeBanner: false,
+      ),
     );
   }
 }

--- a/yoochanhong_and_children/pubspec.lock
+++ b/yoochanhong_and_children/pubspec.lock
@@ -70,6 +70,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  flutter_screenutil:
+    dependency: "direct main"
+    description:
+      name: flutter_screenutil
+      sha256: "1b61f8c4cbf965104b6ca7160880ff1af6755aad7fec70b58444245132453745"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -186,3 +194,4 @@ packages:
     version: "2.1.4"
 sdks:
   dart: ">=3.0.3 <4.0.0"
+  flutter: ">=3.10.0"

--- a/yoochanhong_and_children/pubspec.yaml
+++ b/yoochanhong_and_children/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  flutter_screenutil: ^5.8.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
ScreenUtil 패키지를 추가하기 위해, pubspec.yaml,lock 파일을 수정하였고,
main.dart에서 디자인 기종에 맞게 기본적인 세팅했습니다.